### PR TITLE
Separar comandos en módulos

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,8 @@ Usa Linux.
 ### Windows
 
 Referirse a la intalación en Windows.
+
+## Cómo crear un comando
+
+Revisar el archivo commands/ping.py a modo de ejemplo.
+Además, ver definiciones base en el archivo commands/base/command.py

--- a/alexis.py
+++ b/alexis.py
@@ -12,7 +12,6 @@ import yaml
 import logger
 import discord
 import commands
-from cleverwrap import CleverWrap
 from models import db, Post, Ban, Redditor, Meme
 from tasks import posts_loop
 
@@ -30,6 +29,7 @@ class Alexis(discord.Client):
         self.log = logger.get_logger('Alexis')
         self.initialized = False
         self.config = {}
+        self.sharedcfg = {}
         self.cmds = {}
         self.swhandlers = {}
         self.mention_handlers = []
@@ -38,10 +38,6 @@ class Alexis(discord.Client):
         db.create_tables([Post, Ban, Redditor, Meme], True)
 
         self.load_config()
-
-        self.cbot = CleverWrap(self.config['cleverbot_key'])
-        self.cbotcheck = False
-        self.conversation = True
 
         # Regex de mención (incluye nicks)
         self.rx_mention = None
@@ -97,14 +93,6 @@ class Alexis(discord.Client):
 
         self.log.debug('Comandos cargados: ' + ', '.join(self.cmds.keys()))
 
-        # Cleverbot
-        self.log.info('Conectando con Cleverbot API...')
-        self.cbotcheck = self.cbot.say('test') is not None
-        if self.cbotcheck:
-            self.log.info('CleverWrap iniciado correctamente.')
-        else:
-            self.log.warning('El valor "cleverbot_key" ("%s") es inválido.', self.config['cleverbot_key'])
-
         # Valores ("memes")
         num_memes = len(self.config['default_memes'])
         if num_memes > 0:
@@ -143,7 +131,6 @@ class Alexis(discord.Client):
         chan = message.channel
         is_pm = message.server is None
         is_owner = self.is_owner(message.author, message.server)
-        frase = random.choice(self.config['frases'])
         own_message = message.author.id == self.user.id
 
         # Mandar PMs al log

--- a/alexis.py
+++ b/alexis.py
@@ -131,6 +131,38 @@ class Alexis(discord.Client):
             else:
                 self.log.info('[PM] %s: %s', author, text)
 
+        # Help handler
+        if text == '!help':
+            helplist = []
+            for i in self.cmds.keys():
+                cmdi = self.cmds[i]
+                cmds = ', '.join(cmdi.name) if isinstance(cmdi.name, list) else cmdi.name
+                helplist.append("- {}: {}".format(cmds, cmdi.help))
+
+            num_memes = len(helplist)
+            if num_memes == 0:
+                await self.send_message(chan, 'No hay comandos disponibles')
+                return
+
+            if not is_pm:
+                await self.send_message(chan, '{}, te enviaré la info vía PM'.format(message.author.mention))
+                return
+
+            # Separar lista de ayuda en mensajes con menos de 2000 carácteres
+            resp_list = ''
+            for helpitem in helplist:
+                if len('```{}\n{}```'.format(resp_list, helpitem)) > 2000:
+                    await self.send_message(message.author, '```{}```'.format(resp_list))
+                    resp_list = ''
+                else:
+                    resp_list = '{}\n{}'.format(resp_list, helpitem)
+
+            # Enviar lista restante
+            if resp_list != '':
+                await self.send_message(message.author, '```{}```'.format(resp_list))
+
+            return
+
         # Command handler
         if text.startswith('!') and len(text) > 1:
             cmd = text.split(' ')[0][1:]
@@ -144,12 +176,6 @@ class Alexis(discord.Client):
                     else:
                         await i.handle(message, i.parse(message))
                 return
-
-        # !version
-        if text == '!version' or text == '!info':
-            info_msg = "```\nAutores: {}\nVersión: {}\nEstado: {}```"
-            info_msg = info_msg.format(__author__, __version__, __status__)
-            await self.send_message(chan, info_msg)
 
         # ! <meme> | ¡<meme>
         elif text.startswith('! ') or text.startswith('¡'):

--- a/alexis.py
+++ b/alexis.py
@@ -6,7 +6,6 @@
 import platform
 import sqlite3
 import sys
-import random
 import re
 import yaml
 import logger
@@ -17,7 +16,7 @@ from tasks import posts_loop
 
 __author__ = 'Nicolás Santisteban, Jonathan Gutiérrez'
 __license__ = 'MIT'
-__version__ = '0.3.0-dev.0+refractor'
+__version__ = '0.3.0-dev'
 __status__ = "Desarrollo"
 
 

--- a/alexis.py
+++ b/alexis.py
@@ -131,6 +131,7 @@ class Alexis(discord.Client):
             else:
                 self.log.info('[PM] %s: %s', author, text)
 
+        # Command handler
         if text.startswith('!') and len(text) > 1:
             cmd = text.split(' ')[0][1:]
             if cmd in self.cmds:

--- a/alexis.py
+++ b/alexis.py
@@ -9,7 +9,6 @@ import sys
 import random
 import re
 import yaml
-import urllib.parse as urlparse
 import logger
 import discord
 import commands
@@ -142,7 +141,7 @@ class Alexis(discord.Client):
                     elif not i.allow_pm and is_pm:
                         await self.send_message(chan, i.pm_error)
                     else:
-                        await i.handle(message)
+                        await i.handle(message, i.parse(message))
                 return
 
         # !version

--- a/alexis.py
+++ b/alexis.py
@@ -155,17 +155,6 @@ class Alexis(discord.Client):
         elif text == '!callate':
             await self.send_message(chan, 'http://i.imgur.com/nZ72crJ.jpg')
 
-        # !f
-        elif text.startswith('!f'):
-            hearts = ['heart', 'hearts', 'yellow_heart', 'green_heart', 'blue_heart', 'purple_heart']
-            if text.strip() == '!f':
-                text = "**{}** ha pedido respetos :{}:".format(author, random.choice(hearts))
-                await self.send_message(chan, text)
-            elif text.startswith('!f ') and len(text) >= 4:
-                respects = text[3:]
-                text = "**{}** ha pedido respetos por **{}** :{}:".format(author, respects, random.choice(hearts))
-                await self.send_message(chan, text)
-
         # !redditor
         elif text.startswith('!redditor '):
             user = text[10:].split(' ')[0].strip()

--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -1,0 +1,4 @@
+from os.path import dirname, basename, isfile
+import glob
+modules = glob.glob(dirname(__file__)+"/*.py")
+__all__ = [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__init__.py')]

--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -1,4 +1,15 @@
 from os.path import dirname, basename, isfile
 import glob
+import inspect
+from commands.base.command import Command
 modules = glob.glob(dirname(__file__)+"/*.py")
-__all__ = [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__init__.py')]
+modules = [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__init__.py')]
+__all__ = modules
+
+classes = []
+for imod in __all__:
+    mod = __import__('commands.' + imod, fromlist=[''])
+
+    for name, obj in inspect.getmembers(mod):
+        if inspect.isclass(obj) and name != 'Command' and issubclass(obj, Command):
+            classes.append(obj)

--- a/commands/altoen.py
+++ b/commands/altoen.py
@@ -1,0 +1,26 @@
+from commands.base.command import Command
+import urllib.parse as urlparse
+import discord
+
+
+class AltoEn(Command):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.name = 'altoen'
+
+    async def handle(self, message):
+        cmd = self.parse(message)
+        if len(cmd.args) < 1:
+            await cmd.answer('Formato: !altoen <str>')
+            return
+
+        altotext = ' '.join(cmd.args[1:])
+
+        if len(altotext) > 25:
+            await cmd.answer('mucho texto, máximo 25 carácteres plix ty')
+            return
+
+        altourl = "https://desu.cl/alto.php?size=1000&text=" + urlparse.quote(altotext)
+        emb = discord.Embed()
+        emb.set_image(url=altourl)
+        await self.bot.send_message(message.channel, embed=emb)

--- a/commands/altoen.py
+++ b/commands/altoen.py
@@ -7,6 +7,7 @@ class AltoEn(Command):
     def __init__(self, bot):
         super().__init__(bot)
         self.name = 'altoen'
+        self.help = 'Muestra una imagen basada en el logo "ALTO EN"'
 
     async def handle(self, message, cmd):
         if len(cmd.args) < 1:

--- a/commands/altoen.py
+++ b/commands/altoen.py
@@ -8,8 +8,7 @@ class AltoEn(Command):
         super().__init__(bot)
         self.name = 'altoen'
 
-    async def handle(self, message):
-        cmd = self.parse(message)
+    async def handle(self, message, cmd):
         if len(cmd.args) < 1:
             await cmd.answer('Formato: !altoen <str>')
             return

--- a/commands/altoen.py
+++ b/commands/altoen.py
@@ -14,8 +14,7 @@ class AltoEn(Command):
             await cmd.answer('Formato: !altoen <str>')
             return
 
-        altotext = ' '.join(cmd.args[1:])
-
+        altotext = ' '.join(cmd.args)
         if len(altotext) > 25:
             await cmd.answer('mucho texto, máximo 25 carácteres plix ty')
             return

--- a/commands/bans.py
+++ b/commands/bans.py
@@ -7,6 +7,7 @@ class BanCmd(Command):
     def __init__(self, bot):
         super().__init__(bot)
         self.name = 'ban'
+        self.help = 'Banea (simbólicamente) a un usuario'
         self.allow_pm = False
         self.pm_error = 'banéame esta xd'
 
@@ -51,6 +52,7 @@ class Bans(Command):
     def __init__(self, bot):
         super().__init__(bot)
         self.name = 'bans'
+        self.help = 'Muestra la cantidad de bans de una persona'
         self.allow_pm = False
         self.pm_error = 'no po wn'
 
@@ -86,6 +88,7 @@ class SetBans(Command):
     def __init__(self, bot):
         super().__init__(bot)
         self.name = 'setbans'
+        self.help = 'Determina la cantidad de baneos de un usuario'
         self.allow_pm = False
         self.pm_error = 'como va a funcionar esta weá por pm wn que chucha'
         self.owner_only = True
@@ -122,6 +125,7 @@ class BanRank(Command):
     def __init__(self, bot):
         super().__init__(bot)
         self.name = ['banrank', '!banrank']
+        self.help = 'Muestra el ranking de usuarios baneados'
         self.allow_pm = False
         self.pm_error = 'como va a funcionar esta weá por pm wn que chucha'
 

--- a/commands/bans.py
+++ b/commands/bans.py
@@ -1,0 +1,150 @@
+from commands.base.command import Command, Message
+from models import Ban
+import random
+
+
+class BanCmd(Command):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.name = 'ban'
+        self.allow_pm = False
+        self.pm_error = 'banéame esta xd'
+
+    async def handle(self, message):
+        cmd = self.parse(message)
+
+        if len(cmd.args) > 1 or len(message.mentions) != 1:
+            await cmd.answer('Formato: !ban <mención>')
+            return
+
+        mention = message.mentions[0]
+        mention_name = Message.final_name(mention)
+
+        if not cmd.is_owner and self.is_owner(mention, message.server):
+            await cmd.answer('nopo wn no hagai esa wea')
+        else:
+            # Actualizar id del último que usó un comando (omitir al mismo bot)
+            if self.bot.last_author is None or not cmd.own:
+                self.bot.last_author = message.author.id
+
+            # Evitar que alguien se banee a si mismo
+            if self.bot.last_author == mention.id:
+                await cmd.anwer('no hagai trampa po wn xd')
+                return
+
+            if not random.randint(0, 1):
+                await cmd.answer('¡**{}** se salvo del ban de milagro!'.format(mention_name))
+                return
+
+            user, _ = Ban.get_or_create(user=mention, server=message.server.id)
+            update = Ban.update(bans=Ban.bans + 1)
+            update = update.where(Ban.user == mention, Ban.server == message.server.id)
+            update.execute()
+
+            if user.bans + 1 == 1:
+                text = 'Uff, ¡**{}** se fue baneado por primera vez!'.format(mention_name)
+            else:
+                text = '¡**{}** se fue baneado otra vez y registra **{} baneos**!'
+                text = text.format(mention_name, user.bans + 1)
+            await cmd.answer(text)
+
+
+class Bans(Command):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.name = 'bans'
+        self.allow_pm = False
+        self.pm_error = 'no po wn'
+
+    async def handle(self, message):
+        cmd = self.parse(message)
+
+        if len(cmd.args) > 1 or len(message.mentions) != 1:
+            await cmd.answer('Formato: !ban <mención>')
+            return
+
+        mention = message.mentions[0]
+        if self.is_owner(mention, message.server):
+            mesg = 'Te voy a decir la cifra exacta: Cuatro mil trescientos cuarenta y '
+            mesg += 'cuatro mil quinientos millones coma cinco bans, ese es el valor.'
+            await cmd.answer(mesg)
+            return
+
+        name = mention.nick if mention.nick is not None else mention.name
+        user, _ = Ban.get_or_create(user=mention, server=message.server.id)
+
+        if user.bans == 0:
+            mesg = "```\nException in thread \"main\" java.lang.NullPointerException\n"
+            mesg += "    at AlexisBot.main(AlexisBot.java:34)\n```"
+        else:
+            word = 'ban' if user.bans == 1 else 'bans'
+            if user.bans == 2:
+                word = '~~papás~~ bans'
+
+            mesg = '**{}** tiene {} {}'.format(name, user.bans, word)
+
+        await cmd.answer(mesg)
+
+
+class SetBans(Command):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.name = 'setbans'
+        self.allow_pm = False
+        self.pm_error = 'como va a funcionar esta weá por pm wn que chucha'
+        self.owner_only = True
+
+    async def handle(self, message):
+        cmd = self.parse(message)
+        is_valid = not (len(cmd.args) < 2 or len(message.mentions) != 1)
+        num_bans = 0
+
+        try:
+            num_bans = int(cmd.args[1])
+        except (IndexError, ValueError):
+            is_valid = False
+
+        if not is_valid:
+            await cmd.answer('Formato: !setbans <mención> <cantidad>')
+            return
+
+        mention = message.mentions[0]
+        user, _ = Ban.get_or_create(user=mention, server=message.server.id)
+        user.bans = num_bans
+        user.save()
+
+        name = Message.final_name(mention)
+        if user.bans == 0:
+            mesg = 'Bans de **{}** reiniciados xd'.format(name)
+            await cmd.answer(mesg)
+        else:
+            word = 'ban' if user.bans == 1 else 'bans'
+            mesg = '**{}** ahora tiene {} {}'.format(name, user.bans, word)
+            await cmd.answer(mesg)
+
+
+class BanRank(Command):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.name = ['banrank', '!banrank']
+        self.allow_pm = False
+        self.pm_error = 'como va a funcionar esta weá por pm wn que chucha'
+
+    async def handle(self, message):
+        cmd = self.parse(message)
+        bans = Ban.select().where(Ban.server == message.channel.server.id).order_by(Ban.bans.desc())
+        banlist = []
+        limit = 10 if message.content == '!!banrank' else 5
+
+        i = 1
+        for item in bans.iterator():
+            banlist.append('{}. {}: {}'.format(i, item.user, item.bans))
+
+            i += 1
+            if i > limit:
+                break
+
+        if len(banlist) == 0:
+            await cmd.answer('No hay bans registrados')
+        else:
+            await cmd.answer('Ranking de bans:\n```\n{}\n```'.format('\n'.join(banlist)))

--- a/commands/bans.py
+++ b/commands/bans.py
@@ -10,9 +10,7 @@ class BanCmd(Command):
         self.allow_pm = False
         self.pm_error = 'banéame esta xd'
 
-    async def handle(self, message):
-        cmd = self.parse(message)
-
+    async def handle(self, message, cmd):
         if len(cmd.args) > 1 or len(message.mentions) != 1:
             await cmd.answer('Formato: !ban <mención>')
             return
@@ -56,9 +54,7 @@ class Bans(Command):
         self.allow_pm = False
         self.pm_error = 'no po wn'
 
-    async def handle(self, message):
-        cmd = self.parse(message)
-
+    async def handle(self, message, cmd):
         if len(cmd.args) > 1 or len(message.mentions) != 1:
             await cmd.answer('Formato: !ban <mención>')
             return
@@ -94,8 +90,7 @@ class SetBans(Command):
         self.pm_error = 'como va a funcionar esta weá por pm wn que chucha'
         self.owner_only = True
 
-    async def handle(self, message):
-        cmd = self.parse(message)
+    async def handle(self, message, cmd):
         is_valid = not (len(cmd.args) < 2 or len(message.mentions) != 1)
         num_bans = 0
 
@@ -130,8 +125,7 @@ class BanRank(Command):
         self.allow_pm = False
         self.pm_error = 'como va a funcionar esta weá por pm wn que chucha'
 
-    async def handle(self, message):
-        cmd = self.parse(message)
+    async def handle(self, message, cmd):
         bans = Ban.select().where(Ban.server == message.channel.server.id).order_by(Ban.bans.desc())
         banlist = []
         limit = 10 if message.content == '!!banrank' else 5

--- a/commands/bans.py
+++ b/commands/bans.py
@@ -19,7 +19,7 @@ class BanCmd(Command):
         mention = message.mentions[0]
         mention_name = Message.final_name(mention)
 
-        if not cmd.is_owner and self.is_owner(mention, message.server):
+        if not cmd.owner and self.is_owner(mention, message.server):
             await cmd.answer('nopo wn no hagai esa wea')
         else:
             # Actualizar id del último que usó un comando (omitir al mismo bot)

--- a/commands/base/command.py
+++ b/commands/base/command.py
@@ -2,7 +2,8 @@ class Command:
     def __init__(self, bot):
         self.bot = bot
 
-    def parse(self, message, bot):
+    @staticmethod
+    def parse(message, bot):
         return Message(message, bot)
 
 
@@ -14,5 +15,7 @@ class Message:
         self.is_pm = message.server is None
         self.own = message.author.id == bot.user.id
 
-    def answer(self, content):
-        self.bot.send_message(self.message.channel, content)
+    async def answer(self, content):
+        self.bot.log.debug('Sending message "%s" to %s', content, self.message.channel)
+        self.bot.log.debug(self.bot)
+        await self.bot.send_message(self.message.channel, content)

--- a/commands/base/command.py
+++ b/commands/base/command.py
@@ -1,6 +1,7 @@
 class Command:
     def __init__(self, bot):
         self.bot = bot
+        self.log = self.bot.log
         self.name = ''
         self.swhandler = None
         self.mention_handler = False

--- a/commands/base/command.py
+++ b/commands/base/command.py
@@ -2,6 +2,8 @@ class Command:
     def __init__(self, bot):
         self.bot = bot
         self.name = ''
+        self.swhandler = None
+        self.mention_handler = False
         self.help = ''
         self.allow_pm = True
         self.pm_error = 'Este comando no se puede usar via PM'

--- a/commands/base/command.py
+++ b/commands/base/command.py
@@ -1,0 +1,7 @@
+class Command:
+    def __init__(self, bot, message):
+        self.bot = bot
+        self.message = message
+        self.author = message.author.name
+        self.is_pm = message.server is None
+        self.own = message.author.id == self.bot.user.id

--- a/commands/base/command.py
+++ b/commands/base/command.py
@@ -13,7 +13,7 @@ class Message:
     def __init__(self, message, bot):
         self.bot = bot
         self.message = message
-        self.author = message.author.name
+        self.author_name = Message.final_name(message.author)
         self.is_pm = message.server is None
         self.own = message.author.id == bot.user.id
 
@@ -25,3 +25,7 @@ class Message:
     async def answer(self, content):
         self.bot.log.debug('Sending message "%s" to %s', content, self.message.channel)
         await self.bot.send_message(self.message.channel, content)
+
+    @staticmethod
+    def final_name(user):
+        return user.nick if hasattr(user, 'nick') and user.nick else user.name

--- a/commands/base/command.py
+++ b/commands/base/command.py
@@ -1,7 +1,18 @@
 class Command:
-    def __init__(self, bot, message):
+    def __init__(self, bot):
+        self.bot = bot
+
+    def parse(self, message, bot):
+        return Message(message, bot)
+
+
+class Message:
+    def __init__(self, message, bot):
         self.bot = bot
         self.message = message
         self.author = message.author.name
         self.is_pm = message.server is None
-        self.own = message.author.id == self.bot.user.id
+        self.own = message.author.id == bot.user.id
+
+    def answer(self, content):
+        self.bot.send_message(self.message.channel, content)

--- a/commands/base/command.py
+++ b/commands/base/command.py
@@ -11,7 +11,9 @@ class Command:
         self.owner_error = 'No puedes usar este comando'
 
     def parse(self, message):
-        return Message(message, self.bot)
+        msg = Message(message, self.bot)
+        msg.owner = self.is_owner(message.author, message.server)
+        return msg
 
     def is_owner(self, member, server):
         if server is None:
@@ -35,6 +37,7 @@ class Message:
         self.author_name = Message.final_name(message.author)
         self.is_pm = message.server is None
         self.own = message.author.id == bot.user.id
+        self.owner = False
 
         allargs = message.content.replace('  ', '').split(' ')
         self.args = [] if len(allargs) == 1 else allargs[1:]

--- a/commands/base/command.py
+++ b/commands/base/command.py
@@ -1,10 +1,12 @@
 class Command:
     def __init__(self, bot):
         self.bot = bot
+        self.name = ''
+        self.allow_pm = True
+        self.owner_only = False
 
-    @staticmethod
-    def parse(message, bot):
-        return Message(message, bot)
+    def parse(self, message):
+        return Message(message, self.bot)
 
 
 class Message:
@@ -15,7 +17,11 @@ class Message:
         self.is_pm = message.server is None
         self.own = message.author.id == bot.user.id
 
+        allargs = message.content.replace('  ', '').split(' ')
+        self.args = [] if len(allargs) == 1 else allargs[1:]
+        self.cmdname = allargs[0][1:]
+        self.text = ' '.join(self.args)
+
     async def answer(self, content):
         self.bot.log.debug('Sending message "%s" to %s', content, self.message.channel)
-        self.bot.log.debug(self.bot)
         await self.bot.send_message(self.message.channel, content)

--- a/commands/base/command.py
+++ b/commands/base/command.py
@@ -2,6 +2,7 @@ class Command:
     def __init__(self, bot):
         self.bot = bot
         self.name = ''
+        self.help = ''
         self.allow_pm = True
         self.pm_error = 'Este comando no se puede usar via PM'
         self.owner_only = False

--- a/commands/base/command.py
+++ b/commands/base/command.py
@@ -3,10 +3,26 @@ class Command:
         self.bot = bot
         self.name = ''
         self.allow_pm = True
+        self.pm_error = 'Este comando no se puede usar via PM'
         self.owner_only = False
+        self.owner_error = 'No puedes usar este comando'
 
     def parse(self, message):
         return Message(message, self.bot)
+
+    def is_owner(self, member, server):
+        if server is None:
+            return False
+
+        if member.id in self.bot.config['owners']:
+            return True
+
+        for role in member.roles:
+            owner_role = server.id + "@" + role.id
+            if owner_role in self.bot.config['owners']:
+                return True
+
+        return False
 
 
 class Message:

--- a/commands/choose.py
+++ b/commands/choose.py
@@ -7,8 +7,7 @@ class Choose(Command):
         super().__init__(bot)
         self.name = 'choose'
 
-    async def handle(self, message):
-        cmd = self.parse(message)
+    async def handle(self, message, cmd):
         options = cmd.text.split("|")
         if len(options) < 2:
             return

--- a/commands/choose.py
+++ b/commands/choose.py
@@ -6,6 +6,7 @@ class Choose(Command):
     def __init__(self, bot):
         super().__init__(bot)
         self.name = 'choose'
+        self.help = 'Elige un elemento al azar de una lista separada por el símbolo "|"'
 
     async def handle(self, message, cmd):
         options = cmd.text.split("|")

--- a/commands/choose.py
+++ b/commands/choose.py
@@ -6,7 +6,6 @@ class Choose(Command):
     def __init__(self, bot):
         super().__init__(bot)
         self.name = 'choose'
-        self.allow_pm = False
 
     async def handle(self, message):
         cmd = self.parse(message)

--- a/commands/choose.py
+++ b/commands/choose.py
@@ -1,0 +1,24 @@
+import random
+from commands.base.command import Command
+
+
+class Choose(Command):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.name = 'choose'
+        self.allow_pm = False
+
+    async def handle(self, message):
+        cmd = self.parse(message)
+        options = cmd.text.split("|")
+        if len(options) < 2:
+            return
+
+        # Validar que no hayan opciones vacías
+        for option in options:
+            if option.strip() == '':
+                return
+
+        answer = random.choice(options).strip()
+        text = 'Yo elijo **{}**'.format(answer)
+        await cmd.answer(text)

--- a/commands/cleverbot.py
+++ b/commands/cleverbot.py
@@ -1,4 +1,6 @@
 from commands.base.command import Command
+from cleverwrap import CleverWrap
+import random
 
 
 class CleverbotHandler(Command):
@@ -7,14 +9,45 @@ class CleverbotHandler(Command):
         self.mention_handler = True
         self.allow_pm = False
 
+        self.cbot = CleverWrap(self.bot.config['cleverbot_key'])
+        self.cbotcheck = False
+        self.bot.sharedcfg['conversation'] = True
+
+        self.log.info('Conectando con Cleverbot API...')
+        self.cbotcheck = self.cbot.say('test') is not None
+        if self.cbotcheck:
+            self.log.info('CleverWrap iniciado correctamente.')
+        else:
+            self.log.warning('El valor "cleverbot_key" es inválido.')
+
     async def handle(self, message, cmd):
-        if not self.bot.rx_mention.match(message.content) or not self.bot.conversation or self.bot.cbotcheck is None:
+        if not self.bot.rx_mention.match(message.content) or self.cbotcheck is None:
             return
+
+        if not self.bot.sharedcfg['conversation']:
+            self.cbot.say('l-lo siento sempai, no puedo hablar ahora uwu')
 
         msg = self.bot.rx_mention.sub('', message.content).strip()
         if msg == '':
+            frase = random.choice(self.bot.config['frases'])
             reply = '{}\n\n*Si querías decirme algo, dílo de la siguiente forma: <@bot> <texto>*'.format(frase)
         else:
-            reply = self.bot.cbot.say(msg)
+            reply = self.cbot.say(msg)
 
         await cmd.answer(reply)
+
+
+class ToggleConversation(Command):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.name = 'toggleconversation'
+        self.help = 'Activa/desactiva la conversación con el bot'
+        self.owner_only = True
+
+        if 'conversation' not in self.bot.sharedcfg:
+            self.bot.sharedcfg['conversation'] = True
+
+    async def handle(self, message, cmd):
+        self.bot.sharedcfg['conversation'] = not self.bot.sharedcfg['conversation']
+        resp = 'activada' if self.bot.sharedcfg['conversation'] else 'desactivada'
+        await cmd.answer('Conversación {}'.format(resp))

--- a/commands/cleverbot.py
+++ b/commands/cleverbot.py
@@ -1,0 +1,20 @@
+from commands.base.command import Command
+
+
+class CleverbotHandler(Command):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.mention_handler = True
+        self.allow_pm = False
+
+    async def handle(self, message, cmd):
+        if not self.bot.rx_mention.match(message.content) or not self.bot.conversation or self.bot.cbotcheck is None:
+            return
+
+        msg = self.bot.rx_mention.sub('', message.content).strip()
+        if msg == '':
+            reply = '{}\n\n*Si querías decirme algo, dílo de la siguiente forma: <@bot> <texto>*'.format(frase)
+        else:
+            reply = self.bot.cbot.say(msg)
+
+        await cmd.answer(reply)

--- a/commands/help.py
+++ b/commands/help.py
@@ -10,9 +10,9 @@ class Help(Command):
     async def handle(self, message, cmd):
         helplist = []
         for i in self.bot.cmds.keys():
-            cmdi = self.bot.cmds[i]
-            cmds = ', '.join(cmdi.name) if isinstance(cmdi.name, list) else cmdi.name
-            helplist.append("- {}: {}".format(cmds, cmdi.help))
+            for j in self.bot.cmds[i]:
+                cmds = ', !'.join(j.name) if isinstance(j.name, list) else j.name
+                helplist.append("- !{}: {}".format(cmds, j.help))
 
         num_memes = len(helplist)
         if num_memes == 0:
@@ -21,7 +21,8 @@ class Help(Command):
 
         if not cmd.is_pm:
             await cmd.answer('{}, te enviaré la info vía PM'.format(message.author.mention))
-            return
+
+        await self.bot.send_message(message.author, 'Estos son mis comandos:')
 
         # Separar lista de ayuda en mensajes con menos de 2000 carácteres
         resp_list = ''

--- a/commands/help.py
+++ b/commands/help.py
@@ -1,0 +1,39 @@
+from commands.base.command import Command
+
+
+class Help(Command):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.name = 'help'
+        self.help = 'Muestra la lista de comandos y su ayuda'
+
+    async def handle(self, message, cmd):
+        helplist = []
+        for i in self.bot.cmds.keys():
+            cmdi = self.bot.cmds[i]
+            cmds = ', '.join(cmdi.name) if isinstance(cmdi.name, list) else cmdi.name
+            helplist.append("- {}: {}".format(cmds, cmdi.help))
+
+        num_memes = len(helplist)
+        if num_memes == 0:
+            await cmd.answer('No hay comandos disponibles')
+            return
+
+        if not cmd.is_pm:
+            await cmd.answer('{}, te enviaré la info vía PM'.format(message.author.mention))
+            return
+
+        # Separar lista de ayuda en mensajes con menos de 2000 carácteres
+        resp_list = ''
+        for helpitem in helplist:
+            if len('```{}\n{}```'.format(resp_list, helpitem)) > 2000:
+                await self.bot.send_message(message.author, '```{}```'.format(resp_list))
+                resp_list = ''
+            else:
+                resp_list = '{}\n{}'.format(resp_list, helpitem)
+
+        # Enviar lista restante
+        if resp_list != '':
+            await self.bot.send_message(message.author, '```{}```'.format(resp_list))
+
+        return

--- a/commands/help.py
+++ b/commands/help.py
@@ -11,8 +11,13 @@ class Help(Command):
         helplist = []
         for i in self.bot.cmds.keys():
             for j in self.bot.cmds[i]:
+                if j.owner_only and not cmd.owner:
+                    continue
+
                 cmds = ', !'.join(j.name) if isinstance(j.name, list) else j.name
-                helplist.append("- !{}: {}".format(cmds, j.help))
+                helpline = "- !{}: {}".format(cmds, j.help)
+                if helpline not in helplist:
+                    helplist.append("- !{}: {}".format(cmds, j.help))
 
         num_memes = len(helplist)
         if num_memes == 0:

--- a/commands/macros.py
+++ b/commands/macros.py
@@ -2,10 +2,11 @@ from commands.base.command import Command
 from models import Meme
 
 
-class MemesSet(Command):
+class MacroSet(Command):
     def __init__(self, bot):
         super().__init__(bot)
         self.name = 'set'
+        self.help = 'Agrega o actualiza un macro'
         self.owner_only = True
 
     async def handle(self, message, cmd):
@@ -21,19 +22,20 @@ class MemesSet(Command):
         meme.save()
 
         if created:
-            msg = 'Valor **{name}** creado'.format(name=meme_name)
-            self.bot.log.info('Meme %s creado con valor: "%s"', meme_name, meme_value)
+            msg = 'Macro **{name}** creado'.format(name=meme_name)
+            self.bot.log.info('Macro %s creado con valor: "%s"', meme_name, meme_value)
         else:
-            msg = 'Valor **{name}** actualizado'.format(name=meme_name)
-            self.bot.log.info('Meme %s actualizado a: "%s"', meme_name, meme_value)
+            msg = 'Macro **{name}** actualizado'.format(name=meme_name)
+            self.bot.log.info('Macro %s actualizado a: "%s"', meme_name, meme_value)
 
         await cmd.answer(msg)
 
 
-class MemesUnset(Command):
+class MacroUnset(Command):
     def __init__(self, bot):
         super().__init__(bot)
         self.name = 'unset'
+        self.help = 'Elimina un macro'
         self.owner_only = True
 
     async def handle(self, message, cmd):
@@ -46,35 +48,37 @@ class MemesUnset(Command):
         try:
             meme = Meme.get(name=meme_name)
             meme.delete_instance()
-            msg = 'Valor **{name}** eliminado'.format(name=meme_name)
+            msg = 'Macro **{name}** eliminado'.format(name=meme_name)
             await cmd.answer(msg)
-            self.bot.log.info('Meme %s eliminado', meme_name)
+            self.bot.log.info('Macro %s eliminado', meme_name)
         except Meme.DoesNotExist:
-            msg = 'El valor con nombre {name} no existe'.format(name=meme_name)
+            msg = 'El macro **{name}** no existe'.format(name=meme_name)
             await cmd.answer(msg)
 
         await cmd.answer(msg)
 
 
-class MemeList(Command):
+class MacroList(Command):
     def __init__(self, bot):
         super().__init__(bot)
         self.name = 'list'
+        self.help = 'Muestra una lista de los nombres de los macros guardados'
 
     async def handle(self, message, cmd):
         namelist = []
         for item in Meme.select().iterator():
             namelist.append(item.name)
 
-        word = 'valor' if len(namelist) == 1 else 'valores'
+        word = 'macros' if len(namelist) == 1 else 'macros'
         resp = 'Hay {} {}: {}'.format(len(namelist), word, ', '.join(namelist))
         await cmd.answer(resp)
 
 
-class MemeSuperList(Command):
+class MacroSuperList(Command):
     def __init__(self, bot):
         super().__init__(bot)
         self.name = '!list'
+        self.help = 'Muestra una lista completa de los macros con sus valores'
         self.owner_only = True
 
     async def handle(self, message, cmd):
@@ -84,10 +88,10 @@ class MemeSuperList(Command):
 
         num_memes = len(memelist)
         if num_memes == 0:
-            await cmd.answer('No hay valores disponibles')
+            await cmd.answer('No hay macros disponibles')
             return
 
-        word = 'valor' if num_memes == 1 else 'valores'
+        word = 'macro' if num_memes == 1 else 'macros'
         resp = 'Hay {} {}:'.format(num_memes, word)
         await cmd.answer(resp)
 

--- a/commands/macros.py
+++ b/commands/macros.py
@@ -107,3 +107,22 @@ class MacroSuperList(Command):
         # Enviar lista restante
         if resp_list != '':
             await cmd.answer('```{}```'.format(resp_list))
+
+
+class MacroUse(Command):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.swhandler = ['! ', '¡']
+
+    async def handle(self, message, cmd):
+        # Actualizar el id de la última persona que usó el comando, omitiendo al mismo bot
+        if self.bot.last_author is None or not cmd.own:
+            self.bot.last_author = message.author.id
+
+        meme_query = cmd.args[0] if message.content.startswith('! ') else message.content[1:].split(' ')[0]
+
+        try:
+            meme = Meme.get(Meme.name == meme_query)
+            await cmd.answer(meme.content)
+        except Meme.DoesNotExist:
+            pass

--- a/commands/memes.py
+++ b/commands/memes.py
@@ -8,8 +8,7 @@ class MemesSet(Command):
         self.name = 'set'
         self.owner_only = True
 
-    async def handle(self, message):
-        cmd = self.parse(message)
+    async def handle(self, message, cmd):
         if len(cmd.args) < 2:
             await cmd.answer('Formato: !set <nombre> <contenido>')
             return
@@ -37,8 +36,7 @@ class MemesUnset(Command):
         self.name = 'unset'
         self.owner_only = True
 
-    async def handle(self, message):
-        cmd = self.parse(message)
+    async def handle(self, message, cmd):
         if len(cmd.args) < 1:
             await cmd.answer('Formato: !unset <nombre>')
             return
@@ -63,9 +61,7 @@ class MemeList(Command):
         super().__init__(bot)
         self.name = 'list'
 
-    async def handle(self, message):
-        cmd = self.parse(message)
-
+    async def handle(self, message, cmd):
         namelist = []
         for item in Meme.select().iterator():
             namelist.append(item.name)
@@ -81,9 +77,7 @@ class MemeSuperList(Command):
         self.name = '!list'
         self.owner_only = True
 
-    async def handle(self, message):
-        cmd = self.parse(message)
-
+    async def handle(self, message, cmd):
         memelist = []
         for item in Meme.select().iterator():
             memelist.append("- {}: {}".format(item.name, item.content))

--- a/commands/memes.py
+++ b/commands/memes.py
@@ -1,0 +1,111 @@
+from commands.base.command import Command
+from models import Meme
+
+
+class MemesSet(Command):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.name = 'set'
+        self.owner_only = True
+
+    async def handle(self, message):
+        cmd = self.parse(message)
+        if len(cmd.args) < 2:
+            await cmd.answer('Formato: !set <nombre> <contenido>')
+            return
+
+        meme_name = cmd.args[0]
+        meme_value = ' '.join(cmd.args[1:])
+
+        meme, created = Meme.get_or_create(name=meme_name)
+        meme.content = meme_value
+        meme.save()
+
+        if created:
+            msg = 'Valor **{name}** creado'.format(name=meme_name)
+            self.bot.log.info('Meme %s creado con valor: "%s"', meme_name, meme_value)
+        else:
+            msg = 'Valor **{name}** actualizado'.format(name=meme_name)
+            self.bot.log.info('Meme %s actualizado a: "%s"', meme_name, meme_value)
+
+        await cmd.answer(msg)
+
+
+class MemesUnset(Command):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.name = 'unset'
+        self.owner_only = True
+
+    async def handle(self, message):
+        cmd = self.parse(message)
+        if len(cmd.args) < 1:
+            await cmd.answer('Formato: !unset <nombre>')
+            return
+
+        meme_name = cmd.args[0]
+
+        try:
+            meme = Meme.get(name=meme_name)
+            meme.delete_instance()
+            msg = 'Valor **{name}** eliminado'.format(name=meme_name)
+            await cmd.answer(msg)
+            self.bot.log.info('Meme %s eliminado', meme_name)
+        except Meme.DoesNotExist:
+            msg = 'El valor con nombre {name} no existe'.format(name=meme_name)
+            await cmd.answer(msg)
+
+        await cmd.answer(msg)
+
+
+class MemeList(Command):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.name = 'list'
+
+    async def handle(self, message):
+        cmd = self.parse(message)
+
+        namelist = []
+        for item in Meme.select().iterator():
+            namelist.append(item.name)
+
+        word = 'valor' if len(namelist) == 1 else 'valores'
+        resp = 'Hay {} {}: {}'.format(len(namelist), word, ', '.join(namelist))
+        await cmd.answer(resp)
+
+
+class MemeSuperList(Command):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.name = '!list'
+        self.owner_only = True
+
+    async def handle(self, message):
+        cmd = self.parse(message)
+
+        memelist = []
+        for item in Meme.select().iterator():
+            memelist.append("- {}: {}".format(item.name, item.content))
+
+        num_memes = len(memelist)
+        if num_memes == 0:
+            await cmd.answer('No hay valores disponibles')
+            return
+
+        word = 'valor' if num_memes == 1 else 'valores'
+        resp = 'Hay {} {}:'.format(num_memes, word)
+        await cmd.answer(resp)
+
+        # Separar lista de memes en mensajes con menos de 2000 carácteres
+        resp_list = ''
+        for meme in memelist:
+            if len('```{}\n{}```'.format(resp_list, meme)) > 2000:
+                await cmd.answer('```{}```'.format(resp_list))
+                resp_list = ''
+            else:
+                resp_list = '{}\n{}'.format(resp_list, meme)
+
+        # Enviar lista restante
+        if resp_list != '':
+            await cmd.answer('```{}```'.format(resp_list))

--- a/commands/owner_cmds.py
+++ b/commands/owner_cmds.py
@@ -1,4 +1,5 @@
 from commands.base.command import Command
+import sys
 
 
 class ToggleConversation(Command):
@@ -26,3 +27,14 @@ class ReloadCmd(Command):
             msg = 'Configuración recargada correctamente'
 
         await cmd.answer(msg)
+
+
+class ShutdownCmd(Command):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.name = 'shutdown'
+        self.owner_only = True
+
+    async def handle(self, message, cmd):
+        await cmd.answer('chao loh vimo')
+        sys.exit(0)

--- a/commands/owner_cmds.py
+++ b/commands/owner_cmds.py
@@ -7,9 +7,7 @@ class ToggleConversation(Command):
         self.name = 'toggleconversation'
         self.owner_only = True
 
-    async def handle(self, message):
-        cmd = self.parse(message)
-
+    async def handle(self, message, cmd):
         self.bot.conversation = not self.bot.conversation
         resp = 'activada' if self.bot.conversation else 'desactivada'
         await cmd.answer('Conversación {}'.format(resp))
@@ -21,9 +19,7 @@ class ReloadCmd(Command):
         self.name = 'reload'
         self.owner_only = True
 
-    async def handle(self, message):
-        cmd = self.parse(message)
-
+    async def handle(self, message, cmd):
         if not self.bot.load_config():
             msg = 'No se pudo recargar la configuración'
         else:

--- a/commands/owner_cmds.py
+++ b/commands/owner_cmds.py
@@ -1,0 +1,32 @@
+from commands.base.command import Command
+
+
+class ToggleConversation(Command):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.name = 'toggleconversation'
+        self.owner_only = True
+
+    async def handle(self, message):
+        cmd = self.parse(message)
+
+        self.bot.conversation = not self.bot.conversation
+        resp = 'activada' if self.bot.conversation else 'desactivada'
+        await cmd.answer('Conversación {}'.format(resp))
+
+
+class ReloadCmd(Command):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.name = 'reload'
+        self.owner_only = True
+
+    async def handle(self, message):
+        cmd = self.parse(message)
+
+        if not self.bot.load_config():
+            msg = 'No se pudo recargar la configuración'
+        else:
+            msg = 'Configuración recargada correctamente'
+
+        await cmd.answer(msg)

--- a/commands/owner_cmds.py
+++ b/commands/owner_cmds.py
@@ -3,19 +3,6 @@ import sys
 import alexis
 
 
-class ToggleConversation(Command):
-    def __init__(self, bot):
-        super().__init__(bot)
-        self.name = 'toggleconversation'
-        self.help = 'Activa/desactiva la conversación con el bot'
-        self.owner_only = True
-
-    async def handle(self, message, cmd):
-        self.bot.conversation = not self.bot.conversation
-        resp = 'activada' if self.bot.conversation else 'desactivada'
-        await cmd.answer('Conversación {}'.format(resp))
-
-
 class ReloadCmd(Command):
     def __init__(self, bot):
         super().__init__(bot)

--- a/commands/owner_cmds.py
+++ b/commands/owner_cmds.py
@@ -1,11 +1,13 @@
 from commands.base.command import Command
 import sys
+import alexis
 
 
 class ToggleConversation(Command):
     def __init__(self, bot):
         super().__init__(bot)
         self.name = 'toggleconversation'
+        self.help = 'Activa/desactiva la conversación con el bot'
         self.owner_only = True
 
     async def handle(self, message, cmd):
@@ -18,6 +20,7 @@ class ReloadCmd(Command):
     def __init__(self, bot):
         super().__init__(bot)
         self.name = 'reload'
+        self.help = 'Recarga la configuración'
         self.owner_only = True
 
     async def handle(self, message, cmd):
@@ -33,8 +36,21 @@ class ShutdownCmd(Command):
     def __init__(self, bot):
         super().__init__(bot)
         self.name = 'shutdown'
+        self.help = 'Detiene el proceso del bot'
         self.owner_only = True
 
     async def handle(self, message, cmd):
         await cmd.answer('chao loh vimo')
         sys.exit(0)
+
+
+class InfoCmd(Command):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.name = ['version', 'info']
+        self.help = 'Muestra la información del bot'
+
+    async def handle(self, message, cmd):
+        info_msg = "```\nAutores: {}\nVersión: {}\nEstado: {}```"
+        info_msg = info_msg.format(alexis.__author__, alexis.__version__, alexis.__status__)
+        await cmd.answer(info_msg)

--- a/commands/ping.py
+++ b/commands/ping.py
@@ -1,0 +1,6 @@
+class Ping:
+    def __init__(self, bot):
+        self.bot = bot
+
+    def handle(self, cmd):
+        pass

--- a/commands/ping.py
+++ b/commands/ping.py
@@ -5,10 +5,7 @@ class Ping(Command):
     def __init__(self, bot):
         super().__init__(bot)
         self.name = 'ping'
-        self.owner_only = False
 
     async def handle(self, message):
-        self.bot.log.debug('Handling !ping')
-        cmd = Command.parse(message, self.bot)
+        cmd = self.parse(message)
         await cmd.answer('Pong!')
-        self.bot.log.debug('Handled !ping')

--- a/commands/ping.py
+++ b/commands/ping.py
@@ -2,8 +2,11 @@ from commands.base.command import Command
 
 
 class Ping(Command):
-    def __init__(self, bot, message):
-        super().__init__(bot, message)
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.name = 'ping'
+        self.owner_only = False
 
-    def handle(self, cmd):
-        pass
+    def handle(self, message):
+        cmd = self.parse(message, self.bot)
+        cmd.answer('Pong!')

--- a/commands/ping.py
+++ b/commands/ping.py
@@ -1,6 +1,9 @@
-class Ping:
-    def __init__(self, bot):
-        self.bot = bot
+from commands.base.command import Command
+
+
+class Ping(Command):
+    def __init__(self, bot, message):
+        super().__init__(bot, message)
 
     def handle(self, cmd):
         pass

--- a/commands/ping.py
+++ b/commands/ping.py
@@ -7,6 +7,8 @@ class Ping(Command):
         self.name = 'ping'
         self.owner_only = False
 
-    def handle(self, message):
-        cmd = self.parse(message, self.bot)
-        cmd.answer('Pong!')
+    async def handle(self, message):
+        self.bot.log.debug('Handling !ping')
+        cmd = Command.parse(message, self.bot)
+        await cmd.answer('Pong!')
+        self.bot.log.debug('Handled !ping')

--- a/commands/ping.py
+++ b/commands/ping.py
@@ -6,6 +6,5 @@ class Ping(Command):
         super().__init__(bot)
         self.name = 'ping'
 
-    async def handle(self, message):
-        cmd = self.parse(message)
+    async def handle(self, message, cmd):
         await cmd.answer('Pong!')

--- a/commands/ping.py
+++ b/commands/ping.py
@@ -5,6 +5,7 @@ class Ping(Command):
     def __init__(self, bot):
         super().__init__(bot)
         self.name = 'ping'
+        self.help = 'Responde al comando *ping*'
 
     async def handle(self, message, cmd):
         await cmd.answer('Pong!')

--- a/commands/redditor.py
+++ b/commands/redditor.py
@@ -7,6 +7,7 @@ class RedditorCmd(Command):
     def __init__(self, bot):
         super().__init__(bot)
         self.name = 'redditor'
+        self.help = 'Muestra la cantidad de posts (registrados por el bot) hechos por un redditor'
 
     async def handle(self, message, cmd):
         user = cmd.args[0]

--- a/commands/redditor.py
+++ b/commands/redditor.py
@@ -8,8 +8,7 @@ class RedditorCmd(Command):
         super().__init__(bot)
         self.name = 'redditor'
 
-    async def handle(self, message):
-        cmd = self.parse(message)
+    async def handle(self, message, cmd):
         user = cmd.args[0]
 
         if user.startswith('/u/'):

--- a/commands/redditor.py
+++ b/commands/redditor.py
@@ -1,0 +1,30 @@
+from commands.base.command import Command
+import re
+from models import Redditor
+
+
+class RedditorCmd(Command):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.name = 'redditor'
+
+    async def handle(self, message):
+        cmd = self.parse(message)
+        user = cmd.args[0]
+
+        if user.startswith('/u/'):
+            user = user[3:]
+        if not re.match('^[a-zA-Z0-9_-]*$', user):
+            return
+
+        redditor, _ = Redditor.get_or_create(name=user.lower())
+
+        if redditor.posts > 0:
+            suffix = 'post' if redditor.posts == 1 else 'posts'
+            text = '**/u/{name}** ha creado **{num}** {suffix}.'
+            text = text.format(name=user, num=redditor.posts, suffix=suffix)
+            await cmd.answer(text)
+        else:
+            text = '**/u/{name}** no ha creado ningún post.'
+            text = text.format(name=user)
+            await cmd.answer(text)

--- a/commands/respects.py
+++ b/commands/respects.py
@@ -9,8 +9,7 @@ class Respects(Command):
         super().__init__(bot)
         self.name = 'f'
 
-    async def handle(self, message):
-        cmd = self.parse(message)
+    async def handle(self, message, cmd):
         msg = '**{}** ha pedido respetos {}'
         heart = random.choice(Respects.hearts)
 

--- a/commands/respects.py
+++ b/commands/respects.py
@@ -8,6 +8,7 @@ class Respects(Command):
     def __init__(self, bot):
         super().__init__(bot)
         self.name = 'f'
+        self.help = 'Muestra que el usuario que ejecuta el comando ha dado respetos'
 
     async def handle(self, message, cmd):
         msg = '**{}** ha pedido respetos {}'

--- a/commands/respects.py
+++ b/commands/respects.py
@@ -1,0 +1,22 @@
+from commands.base.command import Command
+import random
+
+
+class Respects(Command):
+    hearts = ['heart', 'hearts', 'yellow_heart', 'green_heart', 'blue_heart', 'purple_heart']
+
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.name = 'f'
+
+    async def handle(self, message):
+        cmd = self.parse(message)
+        msg = '**{}** ha pedido respetos {}'
+        heart = random.choice(Respects.hearts)
+
+        if cmd.text == '':
+            msg = msg.format(cmd.author_name, ':{}:'.format(heart))
+        else:
+            msg = msg.format(cmd.author_name, 'por **{}** :{}:'.format(cmd.text, heart))
+
+        await cmd.answer(msg)


### PR DESCRIPTION
La idea es meter los comandos en una carpeta (no necesariamente un archivo por comando), con algunas funcionalidades extras y útiles, como shorthands para hacer cosas repetitivas, como revisar si es un PM, responder al mensaje, etc.

Características:
- Permite colocar comandos en clases dentro de módulos, dentro de la carpeta commands o subcarpetas dentro de esta carpeta
- Permite denegar el acceso a un comando o su uso vía PM según un atributo
- Permite manejar mención propia
- Permite manejar mensajes que comienzan con X texto

TODO:

- [x] Mover el resto de comandos
- [x] Agregar startswith como opción de hook (somehow)
- [x] Agregar mención como opción de hook (por ejemplo, la funcionalidad de Cleverbot)
- [x] Implementar !help (#17)
- [x] Separar Cleverbot 
- [x] you tell me xd