### PR TITLE
Configuración de subs y embeds

### DIFF
--- a/alexis.py
+++ b/alexis.py
@@ -17,7 +17,7 @@ from tasks import posts_loop
 
 __author__ = 'Nicolás Santisteban, Jonathan Gutiérrez'
 __license__ = 'MIT'
-__version__ = '0.1.9-dev.1'
+__version__ = '0.1.10-dev.0+subsconfig.1'
 __status__ = "Desarrollo"
 
 
@@ -50,6 +50,7 @@ class Alexis(discord.Client):
         self.log.info('Python %s en %s.', sys.version, sys.platform)
         self.log.info(platform.uname())
         self.log.info('Soporte SQLite3 para versión %s.', sqlite3.sqlite_version)
+        self.log.info('discord.py versión %s.', discord.__version__)
         self.log.info('------')
 
         # Cleverbot

--- a/alexis.py
+++ b/alexis.py
@@ -32,20 +32,7 @@ class Alexis(discord.Client):
         db.connect()
         db.create_tables([Post, Ban, Redditor, Meme], True)
 
-        try:
-            with open('config.yml', 'r') as file:
-                self.config = yaml.safe_load(file)
-
-            # Completar info con defaults
-            if 'owners' not in self.config:
-                self.config['owners'] = []
-            if 'default_memes' not in self.config:
-                self.config['default_memes'] = []
-            if 'frases' not in self.config:
-                self.config['frases'] = []
-        except Exception as ex:
-            self.log.exception(ex)
-            raise
+        self.load_config()
 
         self.cbot = CleverWrap(self.config['cleverbot_key'])
         self.cbotcheck = False
@@ -420,6 +407,18 @@ class Alexis(discord.Client):
             resp = 'activada' if self.conversation else 'desactivada'
             await self.send_message(chan, 'Conversación {}'.format(resp))
 
+        elif text == '!reload':
+            if not is_owner:
+                await self.send_message(chan, 'USUARIO NO AUTORIZADO, ACCESO DENEGADO')
+                return
+
+            if not self.load_config():
+                msg = 'No se pudo recargar la configuración'
+            else:
+                msg = 'Configuración recargada correctamente'
+
+            await self.send_message(chan, msg)
+
         # Cleverbot (@bot <mensaje>)
         elif self.rx_mention.match(text) and self.conversation and self.cbotcheck is not None:
             if is_pm:
@@ -432,6 +431,25 @@ class Alexis(discord.Client):
                 reply = self.cbot.say(msg)
 
             await self.send_message(chan, reply)
+
+    def load_config(self):
+        try:
+            with open('config.yml', 'r') as file:
+                config = yaml.safe_load(file)
+
+            # Completar info con defaults
+            if 'owners' not in config:
+                config['owners'] = []
+            if 'default_memes' not in config:
+                config['default_memes'] = []
+            if 'frases' not in config:
+                config['frases'] = []
+
+            self.config = config
+            return True
+        except Exception as ex:
+            self.log.exception(ex)
+            return False
 
     def is_owner(self, member, server):
         if server is None:

--- a/alexis.py
+++ b/alexis.py
@@ -17,7 +17,7 @@ from tasks import posts_loop
 
 __author__ = 'Nicolás Santisteban, Jonathan Gutiérrez'
 __license__ = 'MIT'
-__version__ = '0.2.0-dev.0+subsconfig.1'
+__version__ = '0.2.0'
 __status__ = "Desarrollo"
 
 

--- a/alexis.py
+++ b/alexis.py
@@ -173,6 +173,10 @@ class Alexis(discord.Client):
                 await self.send_message(chan, 'banéame esta xd')
                 return
 
+            if len(text.split(' ')) > 2 or len(message.mentions) != 1:
+                await self.send_message(chan, 'Formato: !ban <mención>')
+                return
+
             mention = message.mentions[0]
             name = self.final_name(mention)
 

--- a/alexis.py
+++ b/alexis.py
@@ -17,7 +17,7 @@ from tasks import posts_loop
 
 __author__ = 'Nicolás Santisteban, Jonathan Gutiérrez'
 __license__ = 'MIT'
-__version__ = '0.1.10-dev.0+subsconfig.1'
+__version__ = '0.2.0-dev.0+subsconfig.1'
 __status__ = "Desarrollo"
 
 

--- a/config.yml.example
+++ b/config.yml.example
@@ -1,7 +1,5 @@
 token: "token"
-channel_id: ["123", "456"]
-channel_nsfw: ["789"]
-subreddit: ["chile", "gonewild"]
+subreddit: ["chile@198944348379938816", "gonewild@248994135317413888,282347946727440394"]
 playing: "/r/chile"
 owners: ["198944348379938816@248581447579860993"]
 default_memes:

--- a/config.yml.example
+++ b/config.yml.example
@@ -1,5 +1,6 @@
 token: "token"
 subreddit: ["chile@198944348379938816", "gonewild@248994135317413888,282347946727440394"]
+default_channel: "168469255979925504"
 playing: "/r/chile"
 owners: ["198944348379938816@248581447579860993"]
 default_memes:

--- a/tasks.py
+++ b/tasks.py
@@ -39,9 +39,11 @@ async def posts_loop(bot):
                 if data['is_self']:
                     embed.description = data['selftext']
                 elif data['media']:
-                    embed.video.url = data['url']
-                    embed.set_thumbnail(url=html.unescape(data['thumbnail']))
-                    embed.description = "Link del video: " + data['url']
+                    if 'preview' in data:
+                        embed.set_image(url=html.unescape(data['preview']['images'][0]['source']['url']))
+                    else:
+                        embed.set_thumbnail(url=html.unescape(data['thumbnail']))
+                    embed.description = "Link del multimedia: " + data['url']
                 elif 'preview' in data:
                     embed.set_image(url=html.unescape(data['preview']['images'][0]['source']['url']))
                 elif data['thumbnail'] != '':

--- a/tasks.py
+++ b/tasks.py
@@ -7,8 +7,15 @@ async def posts_loop(bot):
     post_id = ''
     await bot.wait_until_ready()
     try:
-        for subreddit in bot.config['subreddit']:
-            posts = get_posts(subreddit)
+        for subconfig in bot.config['subreddit']:
+            subconfig = subconfig.split('@')
+            if len(subconfig) < 2:
+                continue
+
+            subname = subconfig[0]
+            subchannels = subconfig[1].split(',')
+            posts = get_posts(subname)
+
             if len(posts) == 0:
                 continue
 
@@ -23,9 +30,8 @@ async def posts_loop(bot):
 
             while data['id'] != post_id and not exists:
                 post_id = data['id']
-                channels = bot.config['channel_nsfw'] if data['over_18'] else bot.config['channel_id']
 
-                for channel in channels:
+                for channel in subchannels:
                     d = 'Nuevo post en **/r/{subreddit}** por **/u/{autor}**: https://www.reddit.com{permalink}'
                     text = d.format(subreddit=data['subreddit'],
                                     autor=data['author'],
@@ -40,7 +46,6 @@ async def posts_loop(bot):
                     Redditor.update(posts=Redditor.posts + 1).where(Redditor.name == data['author'].lower()).execute()
                     bot.log.info('/u/{author} ha sumado un nuevo post, quedando en {num}.'.format(author=data['author'],
                                                                                                   num=redditor.posts + 1))
-
 
     except Exception as e:
         bot.log.error(e)

--- a/tasks.py
+++ b/tasks.py
@@ -11,7 +11,10 @@ async def posts_loop(bot):
         for subconfig in bot.config['subreddit']:
             subconfig = subconfig.split('@')
             if len(subconfig) < 2:
-                continue
+                if 'default_channel' in bot.config and bot.config['default_channel'] != '':
+                    subconfig.append(bot.config['default_channel'])
+                else:
+                    continue
 
             subname = subconfig[0]
             subchannels = subconfig[1].split(',')

--- a/tasks.py
+++ b/tasks.py
@@ -38,9 +38,13 @@ async def posts_loop(bot):
 
                 if data['is_self']:
                     embed.description = data['selftext']
-                elif 'preview' in data and len(data['preview']['images']) > 0:
+                elif data['media']:
+                    embed.video.url = data['url']
+                    embed.set_thumbnail(url=html.unescape(data['thumbnail']))
+                    embed.description = "Link del video: " + data['url']
+                elif 'preview' in data:
                     embed.set_image(url=html.unescape(data['preview']['images'][0]['source']['url']))
-                else:
+                elif data['thumbnail'] != '':
                     embed.set_thumbnail(url=html.unescape(data['thumbnail']))
 
                 for channel in subchannels:

--- a/tasks.py
+++ b/tasks.py
@@ -34,7 +34,7 @@ async def posts_loop(bot):
                 embed = discord.Embed()
                 embed.title = data['title']
                 embed.set_author(name='/u/' + data['author'], url='https://www.reddit.com/user/' + data['author'])
-                embed.url = 'https://reddit.com' + data['permalink']
+                embed.url = 'https://www.reddit.com' + data['permalink']
 
                 if data['is_self']:
                     embed.description = data['selftext']


### PR DESCRIPTION
Mapeo distinto de monitor de posts y mostrar posts como embeds.
- Cada sub a monitorear se debe vincular con el/los channel-ids a los que se enviarán los posts. Esto permite enviar los posts a cualquier canal, y no sólo distinguir por su tipo de contenido (over-18 o no)
- Si se define el `default_channel`, no es necesario agregar el channel-id a los subs. Este igual puede ser una lista de canales separados por coma.

Además, agregar !reload para recargar la configuración en tiempo de ejecución. 